### PR TITLE
feat(Parser): implement BlockStatement, BinaryExpression and ParenthesizedStatement rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,31 @@ The output printed on the screen
       ],
       "body": {
         "type": "BlockStatement",
-        "body": []
+        "body": [
+          {
+            "type": "ReturnStatement",
+            "expr": {
+              "type": "BinaryExpression",
+              "left": {
+                "type": "BinaryExpression",
+                "left": {
+                  "type": "Identifier",
+                  "name": "a"
+                },
+                "operator": "+",
+                "right": {
+                  "type": "Identifier",
+                  "name": "b"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "type": "NumericLiteral",
+                "value": 2
+              }
+            }
+          }
+        ]
       }
     },
     {
@@ -125,5 +149,4 @@ The output printed on the screen
     }
   ]
 }
-
 ```

--- a/src/Parser/Parser.spec.ts
+++ b/src/Parser/Parser.spec.ts
@@ -16,13 +16,17 @@ function BlockStatement(body: any[]) {
   return { type: 'BlockStatement', body };
 }
 
+function ReturnStatement(expr: any) {
+  return { type: 'ReturnStatement', expr };
+}
+
 function Program(body: any[]) {
   return { type: 'Program', body };
 }
 
 const functionDeclaration = `
 fun average(a, b) {
-  return (a + b) / 2
+  return 1
 }
 `;
 
@@ -38,13 +42,7 @@ describe('Parser', () => {
         type: 'FunctionDeclaration',
         name: Identifier('average'),
         params: [Identifier('a'), Identifier('b')],
-        body: BlockStatement([
-          //   BinaryExpression(
-          //     BinaryExpression(Identifier('a'), '+', Identifier('b')),
-          //     '/',
-          //     NumericLiteral(2)
-          //   ),
-        ]),
+        body: BlockStatement([ReturnStatement(NumericLiteral(1))]),
       },
     ]);
 
@@ -83,13 +81,7 @@ describe('Parser', () => {
         type: 'FunctionDeclaration',
         name: Identifier('average'),
         params: [Identifier('a'), Identifier('b')],
-        body: BlockStatement([
-          //   BinaryExpression(
-          //     BinaryExpression(Identifier('a'), '+', Identifier('b')),
-          //     '/',
-          //     NumericLiteral(2)
-          //   ),
-        ]),
+        body: BlockStatement([ReturnStatement(NumericLiteral(1))]),
       },
 
       {

--- a/src/Parser/Parser.spec.ts
+++ b/src/Parser/Parser.spec.ts
@@ -26,7 +26,7 @@ function Program(body: any[]) {
 
 const functionDeclaration = `
 fun average(a, b) {
-  return 1
+  return (a + b) / 2
 }
 `;
 
@@ -42,7 +42,15 @@ describe('Parser', () => {
         type: 'FunctionDeclaration',
         name: Identifier('average'),
         params: [Identifier('a'), Identifier('b')],
-        body: BlockStatement([ReturnStatement(NumericLiteral(1))]),
+        body: BlockStatement([
+          ReturnStatement(
+            BinaryExpression(
+              BinaryExpression(Identifier('a'), '+', Identifier('b')),
+              '/',
+              NumericLiteral(2)
+            )
+          ),
+        ]),
       },
     ]);
 
@@ -81,7 +89,15 @@ describe('Parser', () => {
         type: 'FunctionDeclaration',
         name: Identifier('average'),
         params: [Identifier('a'), Identifier('b')],
-        body: BlockStatement([ReturnStatement(NumericLiteral(1))]),
+        body: BlockStatement([
+          ReturnStatement(
+            BinaryExpression(
+              BinaryExpression(Identifier('a'), '+', Identifier('b')),
+              '/',
+              NumericLiteral(2)
+            )
+          ),
+        ]),
       },
 
       {

--- a/src/Parser/Parser.ts
+++ b/src/Parser/Parser.ts
@@ -57,7 +57,18 @@ export default class Parser extends GenericParser {
     return statements;
   }
 
+  // @TODO: Statement -> Expression
   private Statement(): Statement {
+    const statement = this._Statement();
+
+    if (this.lookahead?.type === 'operator') {
+      return this.BinaryExpression(statement);
+    }
+
+    return statement;
+  }
+
+  private _Statement(): Statement {
     if (this.lookahead?.type === 'leftParen') {
       return this.ParenthesizedStatement();
     } else if (this.lookahead?.type === 'identifier') {
@@ -89,7 +100,7 @@ export default class Parser extends GenericParser {
 
       return numericLiteral;
     } else {
-      throw new Error(`Could not parse ${this.lookahead?.type}`);
+      throw new Error(`Could not parse ${JSON.stringify(this.lookahead)}`);
     }
   }
 

--- a/src/Parser/Parser.ts
+++ b/src/Parser/Parser.ts
@@ -92,13 +92,15 @@ export default class Parser extends GenericParser {
   private BlockStatement(): BlockStatement {
     this.match('leftBrace');
 
-    let next = this.match();
+    const body = [];
 
-    while (next?.type !== 'rightBrace') {
-      next = this.match();
+    while (this.lookahead?.type !== 'rightBrace') {
+      body.push(this.Statement());
     }
 
-    return { type: 'BlockStatement', body: [] };
+    this.match('rightBrace');
+
+    return { type: 'BlockStatement', body };
   }
 
   private FunctionDeclaration(): FunctionDeclaration {


### PR DESCRIPTION
**Changes:**

- update and activate `BlockStatement` tests (tdd)
- include statements in BlockStatement
- add `BinaryExpression` tests (tdd)
- implement `ParenthesizedStatement` rule
- implement `BinaryExpression` rule
- correctly recognize complex expressions, i.e. (a + b) / 2
- update output example in the README

**Preview:**

| <img width="296" alt="Screenshot 2021-10-14 at 01 47 55" src="https://user-images.githubusercontent.com/90652/137227991-30fd16ac-cea1-45d3-87e6-4cc8d3a89abc.png"> |
|:-:|


**Next:**

- Precedence